### PR TITLE
Add image for last place jersey rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,9 @@
           <li>Second place: 30%</li>
           <li>Third place: 10%</li>
           <li>Bitch Bowl Winner (Losers Bracket Winner): $50 bucks</li>
-          <li>Last place: must wear the Losers Jersey at the next draft</li>
+          <li>Last place: must wear the Losers Jersey at the next draft.<br />
+            <img src="losers-jersey.jpg" alt="Loser's Jersey" class="loser-jersey" />
+          </li>
         </ul>
       </section>
 
@@ -63,7 +65,9 @@
         <h2><i class="fa-solid fa-book-open"></i> League By-Laws</h2>
         <p>Below is a concise overview of our league&rsquo;s by-laws. These govern roster construction, scoring, waivers and fair play. Reach out to the commissioner if you have any questions!</p>
           <ol>
-            <li>Loser&rsquo;s Jersey Rule &ndash; The last-place finisher must wear the loser&rsquo;s jersey to the following year&rsquo;s draft.</li>
+            <li>Loser&rsquo;s Jersey Rule &ndash; The last-place finisher must wear the loser&rsquo;s jersey to the following year&rsquo;s draft.<br />
+              <img src="losers-jersey.jpg" alt="Loser's Jersey" class="loser-jersey" />
+            </li>
             <li>Mandatory Trade Rule &ndash; Each manager must make at least one trade during the season. If not, they are ineligible to win the championship.</li>
             <li>Draft Day Attendance Rule &ndash; If you do not attend draft day (in person or via Zoom), you cannot have the 1st pick. You move down one spot until the first attending manager is eligible.</li>
             <li>Roster Lock Rule &ndash; Teams that do not make the playoffs have their rosters locked (no waiver adds/drops or lineup changes).</li>

--- a/style.css
+++ b/style.css
@@ -191,6 +191,14 @@ main {
   line-height: 1.4;
 }
 
+/* Loser's jersey image styling */
+.loser-jersey {
+  max-width: 200px;
+  margin-top: 0.5rem;
+  display: block;
+  border-radius: 8px;
+}
+
 /* Standings table */
 .table-container {
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- display the fantasy-football "loser's jersey" image alongside rule references
- style jersey image for consistent sizing and spacing
- remove the placeholder jersey image file so the repo stays lean (add your own `losers-jersey.jpg` at the project root)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c812f88483219462bd5a3c5b6981